### PR TITLE
カレンダーの表示月を変更可能にした

### DIFF
--- a/src/components/CalenderBoard.tsx
+++ b/src/components/CalenderBoard.tsx
@@ -3,6 +3,8 @@ import { makeStyles, Typography, StyledProps } from '@material-ui/core';
 import { Calender, daysOfWeek } from 'lib/calender';
 import { grey, red, indigo } from '@material-ui/core/colors';
 import { CalenderCell } from './CalenderCell';
+import { CalenderHead } from './CalenderHead';
+import { CalenderBoardHandler } from 'containers/CalenderBoardContainer';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -48,14 +50,16 @@ const useStyles = makeStyles(theme => ({
   saturDay: { backgroundColor: indigo[100] },
 }));
 
-type Props = {
+interface OwnProps {
   year: number;
   month: number;
-};
+}
+
+type Props = OwnProps & CalenderBoardHandler;
 
 export const CalenderBoard: React.FC<Props> = props => {
   const classes = useStyles({} as StyledProps);
-  const { year, month } = props;
+  const { year, month, handleChangeMonth } = props;
   const calender = Calender.getInstance(year, month);
   const styleOfDaysOfWeek: (day: number) => string = day => {
     const baseStyle = classes.element + ' ' + classes.dayOfWeek;
@@ -68,11 +72,18 @@ export const CalenderBoard: React.FC<Props> = props => {
         return baseStyle;
     }
   };
+  const handleChangeToPrevMonth: () => void = () => {
+    handleChangeMonth(calender.prevMonth());
+  };
+  const handleChangeToNextMonth: () => void = () => {
+    handleChangeMonth(calender.nextMonth());
+  };
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle2">{year}</Typography>
-      <Typography variant="h1">{month}</Typography>
+      <CalenderHead
+        {...{ ...props, handleChangeToPrevMonth, handleChangeToNextMonth }}
+      />
       <div className={classes.elements + ' ' + classes.dayOfWeek}>
         {daysOfWeek.map((d, i) => (
           <div key={i} className={styleOfDaysOfWeek(i)}>

--- a/src/components/CalenderBoard.tsx
+++ b/src/components/CalenderBoard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeStyles, Typography, StyledProps } from '@material-ui/core';
-import { createCalender, daysOfWeek } from 'lib/calender';
+import { Calender, daysOfWeek } from 'lib/calender';
 import { grey, red, indigo } from '@material-ui/core/colors';
 import { CalenderCell } from './CalenderCell';
 
@@ -56,6 +56,7 @@ type Props = {
 export const CalenderBoard: React.FC<Props> = props => {
   const classes = useStyles({} as StyledProps);
   const { year, month } = props;
+  const calender = Calender.getInstance(year, month);
   const styleOfDaysOfWeek: (day: number) => string = day => {
     const baseStyle = classes.element + ' ' + classes.dayOfWeek;
     switch (day) {
@@ -80,7 +81,7 @@ export const CalenderBoard: React.FC<Props> = props => {
         ))}
       </div>
       <div className={classes.elements}>
-        {createCalender(year, month).map((c, i) => (
+        {calender.calenderElements.map((c, i) => (
           <CalenderCell index={i} element={c} classes={classes} />
         ))}
       </div>

--- a/src/components/CalenderHead.tsx
+++ b/src/components/CalenderHead.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { makeStyles, Typography, IconButton, Grid } from '@material-ui/core';
+import { ChevronLeft, ChevronRight } from '@material-ui/icons';
+
+const useStyles = makeStyles(() => ({
+  title: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+}));
+
+type Props = {
+  year: number;
+  month: number;
+  handleChangeToPrevMonth(): void;
+  handleChangeToNextMonth(): void;
+};
+
+export const CalenderHead: React.FC<Props> = props => {
+  const classes = useStyles();
+  const {
+    year,
+    month,
+    handleChangeToPrevMonth,
+    handleChangeToNextMonth,
+  } = props;
+
+  return (
+    <Grid container justify="center" alignItems="center">
+      <Grid item alignItems="center">
+        <IconButton onClick={handleChangeToPrevMonth}>
+          <ChevronLeft />
+        </IconButton>
+      </Grid>
+      <Grid item xs={7}>
+        <div className={classes.title}>
+          <Typography variant="subtitle2">{year}</Typography>
+          <Typography variant="h1">{month}</Typography>
+        </div>
+      </Grid>
+      <Grid item alignItems="center">
+        <IconButton onClick={handleChangeToNextMonth}>
+          <ChevronRight />
+        </IconButton>
+      </Grid>
+    </Grid>
+  );
+};

--- a/src/containers/CalenderBoardContainer.ts
+++ b/src/containers/CalenderBoardContainer.ts
@@ -1,6 +1,6 @@
 import { Appstate } from 'redux/store';
 import { connect } from 'react-redux';
-import { InputActions } from 'redux/actions';
+import { CalenderActions } from 'redux/actions';
 import { CalenderBoard } from 'components/CalenderBoard';
 import { Dispatch } from 'react';
 
@@ -9,10 +9,8 @@ interface StateAtProps {
   month: number;
 }
 
-export type TopPageHandler = {
-  handleOnChangeValue(value: string): void;
-  handleOnSelectValue(value: string): void;
-  handleOnClick(): void;
+export type CalenderBoardHandler = {
+  handleChangeMonth(value: { year: number; month: number }): void;
 };
 
 const mapStateToProps = (appState: Appstate): StateAtProps => {
@@ -22,16 +20,10 @@ const mapStateToProps = (appState: Appstate): StateAtProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch<any>): TopPageHandler => {
+const mapDispatchToProps = (dispatch: Dispatch<any>): CalenderBoardHandler => {
   return {
-    handleOnChangeValue: (value: string) => {
-      dispatch(InputActions.updateTextInputValue(value));
-    },
-    handleOnSelectValue: (value: string) => {
-      dispatch(InputActions.updateSelectedValue(value));
-    },
-    handleOnClick: () => {
-      dispatch(InputActions.updateCount());
+    handleChangeMonth: ({ year, month }) => {
+      dispatch(CalenderActions.updateCurrentMonth({ year, month }));
     },
   };
 };

--- a/src/containers/CalenderBoardContainer.ts
+++ b/src/containers/CalenderBoardContainer.ts
@@ -9,9 +9,9 @@ interface StateAtProps {
   month: number;
 }
 
-export type CalenderBoardHandler = {
+export interface CalenderBoardHandler {
   handleChangeMonth(value: { year: number; month: number }): void;
-};
+}
 
 const mapStateToProps = (appState: Appstate): StateAtProps => {
   return {

--- a/src/lib/calender.ts
+++ b/src/lib/calender.ts
@@ -21,7 +21,7 @@ class CalenderElement implements CalenderElementable {
 
 const daysOfMonth = [31, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
-class Calender implements Calenderable {
+export class Calender implements Calenderable {
   private static instance: Calender;
   private _calenderElements: Array<CalenderElement> = [];
   private constructor(readonly year: number, readonly month: number) {}
@@ -37,6 +37,18 @@ class Calender implements Calenderable {
       return 29;
     }
     return daysOfMonth[month];
+  }
+  prevMonth(): { year: number; month: number } {
+    if (this.month === 1) {
+      return { year: this.year - 1, month: 12 };
+    }
+    return { year: this.year, month: this.month - 1 };
+  }
+  nextMonth(): { year: number; month: number } {
+    if (this.month === 12) {
+      return { year: this.year + 1, month: 1 };
+    }
+    return { year: this.year, month: this.month + 1 };
   }
   createCalenderElements(
     days: number,
@@ -63,14 +75,6 @@ class Calender implements Calenderable {
 
     return this._calenderElements;
   }
-}
-
-export function createCalender(
-  year: number,
-  month: number
-): Array<CalenderElement> {
-  const calender = Calender.getInstance(year, month);
-  return calender.calenderElements;
 }
 
 export const daysOfWeek = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -7,3 +7,9 @@ export const InputActions = {
   updateSelectedValue: actionCreater<string>('UPDATE_SELECTED_VALUE'),
   updateCount: actionCreater('UPDATE_CLICK_COUNT'),
 };
+
+export const CalenderActions = {
+  updateCurrentMonth: actionCreater<{ year: number; month: number }>(
+    'UPDATE_CURRENT_MONTH'
+  ),
+};

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -1,5 +1,5 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
-import { InputActions } from 'redux/actions';
+import { InputActions, CalenderActions } from 'redux/actions';
 
 export interface State {
   inputValue: string;
@@ -26,4 +26,7 @@ export const Reducer = reducerWithInitialState(initialState)
   })
   .case(InputActions.updateCount, state => {
     return { ...state, clickCount: state.clickCount + 1 };
+  })
+  .case(CalenderActions.updateCurrentMonth, (state, { year, month }) => {
+    return { ...state, year, month };
   });


### PR DESCRIPTION
## 🍔 やったこと
### view
- カレンダーの表示月を前後月に変更できるボタンを設置.
- 年, 月の表示とボタンを`CalenderHead`として別コンポーネントで切り出し.
### logic
- `State`の`year, month`を変更するためのアクション及びディスパッチャを定義.
- ロジックを担当する`Calender`クラスに, 自身の持つ前後月を返すメソッドをそれぞれ作成.
<br />

## 🍣 できるようになったこと
- カレンダーの表示月を変更できるようになった.

![200304-changemonth](https://user-images.githubusercontent.com/39250854/75891476-2d26f800-5e73-11ea-98e5-dfc09705717a.gif)

<br />

## 🍕 やってないこと
### view, logic
- イベントの追加.
<br />