### PR TITLE
イベントの表示

### DIFF
--- a/src/components/CalenderBoard.tsx
+++ b/src/components/CalenderBoard.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { makeStyles, Typography, StyledProps } from '@material-ui/core';
-import { Calender, DAYS_OF_WEEK } from 'lib/calender';
+import { Calender } from 'lib/calender';
 import { grey, red, indigo } from '@material-ui/core/colors';
 import { CalenderCell } from './CalenderCell';
 import { CalenderHead } from './CalenderHead';
 import { CalenderBoardHandler } from 'containers/CalenderBoardContainer';
 import { Event } from 'lib/event';
+import { DAYS_OF_WEEK } from 'lib/common';
 
 const useStyles = makeStyles(theme => ({
   root: {

--- a/src/components/CalenderBoard.tsx
+++ b/src/components/CalenderBoard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeStyles, Typography, StyledProps } from '@material-ui/core';
-import { Calender, daysOfWeek } from 'lib/calender';
+import { Calender, DAYS_OF_WEEK } from 'lib/calender';
 import { grey, red, indigo } from '@material-ui/core/colors';
 import { CalenderCell } from './CalenderCell';
 import { CalenderHead } from './CalenderHead';
@@ -85,7 +85,7 @@ export const CalenderBoard: React.FC<Props> = props => {
         {...{ ...props, handleChangeToPrevMonth, handleChangeToNextMonth }}
       />
       <div className={classes.elements + ' ' + classes.dayOfWeek}>
-        {daysOfWeek.map((d, i) => (
+        {DAYS_OF_WEEK.map((d, i) => (
           <div key={i} className={styleOfDaysOfWeek(i)}>
             <Typography>{d}</Typography>
           </div>
@@ -93,7 +93,9 @@ export const CalenderBoard: React.FC<Props> = props => {
       </div>
       <div className={classes.elements}>
         {calender.calenderElements.map((c, i) => (
-          <CalenderCell index={i} element={c} classes={classes} />
+          <div key={i}>
+            <CalenderCell index={i} element={c} classes={classes} />
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/CalenderBoard.tsx
+++ b/src/components/CalenderBoard.tsx
@@ -96,7 +96,7 @@ export const CalenderBoard: React.FC<Props> = props => {
       <div className={classes.elements}>
         {calender.calenderElements.map((c, i) => (
           <div key={i}>
-            <CalenderCell index={i} element={c} classes={classes} />
+            <CalenderCell element={c} classes={classes} />
           </div>
         ))}
       </div>

--- a/src/components/CalenderBoard.tsx
+++ b/src/components/CalenderBoard.tsx
@@ -73,17 +73,6 @@ export const CalenderBoard: React.FC<Props> = props => {
   const classes = useStyles({} as StyledProps);
   const { year, month, events, handleChangeMonth } = props;
   const calender = Calender.getInstance(year, month, events);
-  const styleOfDaysOfWeek: (day: number) => string = day => {
-    const baseStyle = classes.element + ' ' + classes.dayOfWeek;
-    switch (day) {
-      // case 0:
-      //   return baseStyle + ' ' + classes.sunDay;
-      // case 6:
-      //   return baseStyle + ' ' + classes.saturDay;
-      default:
-        return baseStyle;
-    }
-  };
   const handleChangeToPrevMonth: () => void = () => {
     handleChangeMonth(calender.prevMonth());
   };
@@ -98,7 +87,7 @@ export const CalenderBoard: React.FC<Props> = props => {
       />
       <div className={classes.elements + ' ' + classes.dayOfWeek}>
         {DAYS_OF_WEEK.map((d, i) => (
-          <div key={i} className={styleOfDaysOfWeek(i)}>
+          <div key={i} className={classes.element + ' ' + classes.dayOfWeek}>
             <Typography>{d}</Typography>
           </div>
         ))}

--- a/src/components/CalenderBoard.tsx
+++ b/src/components/CalenderBoard.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles(theme => ({
   element: {
     width: '10vw',
     height: 96,
-    padding: 4,
+    padding: 2,
     boxSizing: 'border-box',
     border: `0.5px solid ${grey[300]}`,
     borderStyle: 'none solid solid none',

--- a/src/components/CalenderBoard.tsx
+++ b/src/components/CalenderBoard.tsx
@@ -45,7 +45,16 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+    color: theme.palette.primary.main,
     backgroundColor: grey[200],
+    '&:first-child': {
+      color: grey[200],
+      backgroundColor: theme.palette.primary.light,
+    },
+    '&:last-child': {
+      color: grey[200],
+      backgroundColor: theme.palette.primary.light,
+    },
   },
   sunDay: { backgroundColor: red[100] },
   saturDay: { backgroundColor: indigo[100] },
@@ -66,10 +75,10 @@ export const CalenderBoard: React.FC<Props> = props => {
   const styleOfDaysOfWeek: (day: number) => string = day => {
     const baseStyle = classes.element + ' ' + classes.dayOfWeek;
     switch (day) {
-      case 0:
-        return baseStyle + ' ' + classes.sunDay;
-      case 6:
-        return baseStyle + ' ' + classes.saturDay;
+      // case 0:
+      //   return baseStyle + ' ' + classes.sunDay;
+      // case 6:
+      //   return baseStyle + ' ' + classes.saturDay;
       default:
         return baseStyle;
     }

--- a/src/components/CalenderBoard.tsx
+++ b/src/components/CalenderBoard.tsx
@@ -5,6 +5,7 @@ import { grey, red, indigo } from '@material-ui/core/colors';
 import { CalenderCell } from './CalenderCell';
 import { CalenderHead } from './CalenderHead';
 import { CalenderBoardHandler } from 'containers/CalenderBoardContainer';
+import { Event } from 'lib/event';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -16,7 +17,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
   },
   elements: {
-    width: 910,
+    width: '70vw',
     display: 'flex',
     flexWrap: 'wrap',
     border: `0.5px solid ${grey[300]}`,
@@ -26,15 +27,15 @@ const useStyles = makeStyles(theme => ({
     },
   },
   element: {
-    width: 130,
-    height: 80,
+    width: '10vw',
+    height: 96,
     padding: 4,
     boxSizing: 'border-box',
     border: `0.5px solid ${grey[300]}`,
     borderStyle: 'none solid solid none',
     [theme.breakpoints.down('sm')]: {
       width: '13vw',
-      height: 64,
+      height: 80,
     },
   },
   out: { color: grey[500] },
@@ -53,14 +54,15 @@ const useStyles = makeStyles(theme => ({
 interface OwnProps {
   year: number;
   month: number;
+  events: Array<Event>;
 }
 
 type Props = OwnProps & CalenderBoardHandler;
 
 export const CalenderBoard: React.FC<Props> = props => {
   const classes = useStyles({} as StyledProps);
-  const { year, month, handleChangeMonth } = props;
-  const calender = Calender.getInstance(year, month);
+  const { year, month, events, handleChangeMonth } = props;
+  const calender = Calender.getInstance(year, month, events);
   const styleOfDaysOfWeek: (day: number) => string = day => {
     const baseStyle = classes.element + ' ' + classes.dayOfWeek;
     switch (day) {

--- a/src/components/CalenderCell.tsx
+++ b/src/components/CalenderCell.tsx
@@ -1,18 +1,7 @@
 import * as React from 'react';
 import { CalenderElement } from 'lib/calenderElement';
-import { Typography, makeStyles } from '@material-ui/core';
-
-const useStyles = makeStyles(theme => ({
-  event: {
-    marginTop: 2,
-    padding: '0 2px',
-    backgroundColor: theme.palette.secondary.light,
-    '&:nth-child(2n)': {
-      color: '#fafafa',
-      backgroundColor: theme.palette.primary.light,
-    },
-  },
-}));
+import { Typography } from '@material-ui/core';
+import { Events } from './Events';
 
 type Props = {
   element: CalenderElement;
@@ -20,7 +9,6 @@ type Props = {
 };
 
 export const CalenderCell: React.FC<Props> = props => {
-  const classes2 = useStyles();
   const { element, classes } = props;
 
   return (
@@ -32,12 +20,7 @@ export const CalenderCell: React.FC<Props> = props => {
       }
     >
       <Typography>{element.date}</Typography>
-      {element.events &&
-        element.events.map((event, i) => (
-          <Typography key={i} variant="body2" className={classes2.event}>
-            {event}
-          </Typography>
-        ))}
+      {element.events.length > 0 && <Events events={element.events} />}
     </div>
   );
 };

--- a/src/components/CalenderCell.tsx
+++ b/src/components/CalenderCell.tsx
@@ -4,10 +4,11 @@ import { Typography, makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
   event: {
-    marginBottom: 2,
+    marginTop: 2,
     padding: '0 2px',
     backgroundColor: theme.palette.secondary.light,
     '&:nth-child(2n)': {
+      color: '#fafafa',
       backgroundColor: theme.palette.primary.light,
     },
   },

--- a/src/components/CalenderCell.tsx
+++ b/src/components/CalenderCell.tsx
@@ -2,17 +2,15 @@ import * as React from 'react';
 import { CalenderElement } from 'lib/calender';
 
 type Props = {
-  index: number;
   element: CalenderElement;
   classes: Record<string, string>;
 };
 
 export const CalenderCell: React.FC<Props> = props => {
-  const { index, element, classes } = props;
+  const { element, classes } = props;
 
   return (
     <div
-      key={index}
       className={
         element.isInCurrentMonth
           ? classes.element

--- a/src/components/CalenderCell.tsx
+++ b/src/components/CalenderCell.tsx
@@ -1,5 +1,17 @@
 import * as React from 'react';
 import { CalenderElement } from 'lib/calender';
+import { Typography, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  event: {
+    marginBottom: 2,
+    padding: '0 2px',
+    backgroundColor: theme.palette.secondary.light,
+    '&:nth-child(2n)': {
+      backgroundColor: theme.palette.primary.light,
+    },
+  },
+}));
 
 type Props = {
   element: CalenderElement;
@@ -7,6 +19,7 @@ type Props = {
 };
 
 export const CalenderCell: React.FC<Props> = props => {
+  const classes2 = useStyles();
   const { element, classes } = props;
 
   return (
@@ -17,8 +30,13 @@ export const CalenderCell: React.FC<Props> = props => {
           : classes.element + ' ' + classes.out
       }
     >
-      {element.date}
-      {element.events && <p>{element.events}</p>}
+      <Typography>{element.date}</Typography>
+      {element.events &&
+        element.events.map((event, i) => (
+          <Typography key={i} variant="body2" className={classes2.event}>
+            {event}
+          </Typography>
+        ))}
     </div>
   );
 };

--- a/src/components/CalenderCell.tsx
+++ b/src/components/CalenderCell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CalenderElement } from 'lib/calender';
+import { CalenderElement } from 'lib/calenderElement';
 import { Typography, makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({

--- a/src/components/CalenderCell.tsx
+++ b/src/components/CalenderCell.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import { CalenderElement } from 'lib/calender';
 
 type Props = {
   index: number;
-  element: { date: number; isInCurrentMonth: boolean };
+  element: CalenderElement;
   classes: Record<string, string>;
 };
 
@@ -19,6 +20,7 @@ export const CalenderCell: React.FC<Props> = props => {
       }
     >
       {element.date}
+      {element.events && <p>{element.events}</p>}
     </div>
   );
 };

--- a/src/components/CalenderHead.tsx
+++ b/src/components/CalenderHead.tsx
@@ -29,7 +29,7 @@ export const CalenderHead: React.FC<Props> = props => {
 
   return (
     <Grid container justify="center" alignItems="center">
-      <Grid item alignItems="center">
+      <Grid item>
         <IconButton onClick={handleChangeToPrevMonth}>
           <ChevronLeft />
         </IconButton>
@@ -40,7 +40,7 @@ export const CalenderHead: React.FC<Props> = props => {
           <Typography variant="h1">{month}</Typography>
         </div>
       </Grid>
-      <Grid item alignItems="center">
+      <Grid item>
         <IconButton onClick={handleChangeToNextMonth}>
           <ChevronRight />
         </IconButton>

--- a/src/components/EventCounter.tsx
+++ b/src/components/EventCounter.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { Filter1, Filter2, Filter3 } from '@material-ui/icons';
+
+type Props = {
+  count: number;
+};
+
+export const EventCounter: React.FC<Props> = props => {
+  const { count } = props;
+  switch (count) {
+    case 1:
+      return <Filter1 color="secondary" fontSize="small" />;
+    case 2:
+      return <Filter2 color="secondary" fontSize="small" />;
+    case 3:
+      return <Filter3 color="secondary" fontSize="small" />;
+    default:
+      return <Filter1 color="secondary" fontSize="small" />;
+  }
+};

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { makeStyles } from '@material-ui/core';
+import { Typography, useMediaQuery } from '@material-ui/core';
+import { EventCounter } from './EventCounter';
+
+const useStyles = makeStyles(theme => ({
+  event: {
+    marginTop: 2,
+    padding: '0 2px',
+    backgroundColor: theme.palette.secondary.light,
+    '&:nth-child(2n)': {
+      color: '#fafafa',
+      backgroundColor: theme.palette.primary.light,
+    },
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
+  },
+  counterWrapper: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 8,
+  },
+}));
+
+type Props = {
+  events: string[];
+};
+
+export const Events: React.FC<Props> = props => {
+  const classes = useStyles();
+  const isDesktop = useMediaQuery('(min-width:960px)');
+  const { events } = props;
+
+  return (
+    <div>
+      {isDesktop ? (
+        events.map((event, i) => (
+          <Typography key={i} variant="body2" className={classes.event}>
+            {event}
+          </Typography>
+        ))
+      ) : (
+        <div className={classes.counterWrapper}>
+          <EventCounter count={events.length} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -8,10 +8,6 @@ const useStyles = makeStyles(theme => ({
     marginTop: 2,
     padding: '0 2px',
     backgroundColor: theme.palette.secondary.light,
-    '&:nth-child(2n)': {
-      color: '#fafafa',
-      backgroundColor: theme.palette.primary.light,
-    },
     [theme.breakpoints.down('sm')]: {
       display: 'none',
     },

--- a/src/containers/CalenderBoardContainer.ts
+++ b/src/containers/CalenderBoardContainer.ts
@@ -3,10 +3,12 @@ import { connect } from 'react-redux';
 import { CalenderActions } from 'redux/actions';
 import { CalenderBoard } from 'components/CalenderBoard';
 import { Dispatch } from 'react';
+import { Event } from 'lib/event';
 
 interface StateAtProps {
   year: number;
   month: number;
+  events: Array<Event>;
 }
 
 export interface CalenderBoardHandler {
@@ -17,6 +19,7 @@ const mapStateToProps = (appState: Appstate): StateAtProps => {
   return {
     year: appState.state.year,
     month: appState.state.month,
+    events: appState.state.events,
   };
 };
 

--- a/src/lib/calender.ts
+++ b/src/lib/calender.ts
@@ -1,3 +1,8 @@
+import { Event, InnerEvent } from './event';
+
+const DAYS_OF_MONTH = [31, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+export const DAYS_OF_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+
 interface CalenderElementable {
   readonly date: number;
   readonly isInCurrentMonth: boolean;
@@ -7,6 +12,7 @@ interface Calenderable {
   readonly year: number;
   readonly month: number;
   readonly calenderElements: Array<CalenderElement>;
+  readonly innerEvents: Array<InnerEvent>;
   firstDay(): string;
   daysOfMonthOfYear(): number;
   createCalenderElements(
@@ -27,15 +33,26 @@ class CalenderElement implements CalenderElementable {
   }
 }
 
-const daysOfMonth = [31, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-
 export class Calender implements Calenderable {
   private static instance: Calender;
   private _calenderElements: Array<CalenderElement> = [];
+  private _innerEvents: Array<InnerEvent> = [];
   private constructor(readonly year: number, readonly month: number) {}
-  static getInstance(year: number, month: number): Calender {
+  static getInstance(
+    year: number,
+    month: number,
+    events: Array<Event> = []
+  ): Calender {
     Calender.instance = new Calender(year, month);
+    if (events) {
+      Calender.instance.filterEvents(events);
+    }
     return Calender.instance;
+  }
+  filterEvents(events: Array<Event>): void {
+    this.innerEvents = events
+      .filter(n => n.date[0] === this.year && n.date[1] === this.month)
+      .map(n => new InnerEvent(n.date[2], n.value));
   }
   firstDay(): string {
     return String(this.month) + ' 1, ' + String(this.year);
@@ -44,7 +61,7 @@ export class Calender implements Calenderable {
     if (this.year % 4 === 0 && this.month === 2) {
       return 29;
     }
-    return daysOfMonth[month];
+    return DAYS_OF_MONTH[month];
   }
   prevMonth(): { year: number; month: number } {
     if (this.month === 1) {
@@ -83,6 +100,10 @@ export class Calender implements Calenderable {
 
     return this._calenderElements;
   }
+  get innerEvents(): Array<InnerEvent> {
+    return this._innerEvents;
+  }
+  set innerEvents(newValue: Array<InnerEvent>) {
+    this._innerEvents = newValue;
+  }
 }
-
-export const daysOfWeek = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];

--- a/src/lib/calender.ts
+++ b/src/lib/calender.ts
@@ -1,6 +1,7 @@
 interface CalenderElementable {
   readonly date: number;
   readonly isInCurrentMonth: boolean;
+  readonly events: string[];
 }
 interface Calenderable {
   readonly year: number;
@@ -16,7 +17,14 @@ interface Calenderable {
 }
 
 class CalenderElement implements CalenderElementable {
+  private _events: string[] = [];
   constructor(readonly date: number, readonly isInCurrentMonth: boolean) {}
+  get events(): string[] {
+    return this._events;
+  }
+  set events(newEvents: string[]) {
+    this._events = newEvents;
+  }
 }
 
 const daysOfMonth = [31, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];

--- a/src/lib/calender.ts
+++ b/src/lib/calender.ts
@@ -22,7 +22,7 @@ interface Calenderable {
   ): Array<CalenderElement>;
 }
 
-class CalenderElement implements CalenderElementable {
+export class CalenderElement implements CalenderElementable {
   private _events: string[] = [];
   constructor(readonly date: number, readonly isInCurrentMonth: boolean) {}
   filterEvents(innerEvents: Array<InnerEvent>): void {
@@ -87,7 +87,9 @@ export class Calender implements Calenderable {
   ): Array<CalenderElement> {
     return new Array(days).fill(0).map((_, i) => {
       const calenderElement = new CalenderElement(i + gap, isIn);
-      calenderElement.filterEvents(this.innerEvents);
+      if (isIn) {
+        calenderElement.filterEvents(this.innerEvents);
+      }
       return calenderElement;
     });
   }

--- a/src/lib/calender.ts
+++ b/src/lib/calender.ts
@@ -1,41 +1,12 @@
 import { Event, InnerEvent } from './event';
+import { CalenderElement } from './calenderElement';
+import { DAYS_OF_MONTH } from './common';
 
-const DAYS_OF_MONTH = [31, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-export const DAYS_OF_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
-
-interface CalenderElementable {
-  readonly date: number;
-  readonly isInCurrentMonth: boolean;
-  readonly events: string[];
-}
 interface Calenderable {
   readonly year: number;
   readonly month: number;
   readonly calenderElements: Array<CalenderElement>;
   readonly innerEvents: Array<InnerEvent>;
-  firstDay(): string;
-  daysOfMonthOfYear(): number;
-  createCalenderElements(
-    days: number,
-    isIn: boolean,
-    gap: number
-  ): Array<CalenderElement>;
-}
-
-export class CalenderElement implements CalenderElementable {
-  private _events: string[] = [];
-  constructor(readonly date: number, readonly isInCurrentMonth: boolean) {}
-  filterEvents(innerEvents: Array<InnerEvent>): void {
-    this.events = innerEvents
-      .filter(n => n.date === this.date)
-      .map(m => m.value);
-  }
-  get events(): string[] {
-    return this._events;
-  }
-  set events(newEvents: string[]) {
-    this._events = newEvents;
-  }
 }
 
 export class Calender implements Calenderable {
@@ -63,22 +34,17 @@ export class Calender implements Calenderable {
     return String(this.month) + ' 1, ' + String(this.year);
   }
   daysOfMonthOfYear(month: number = this.month): number {
-    if (this.year % 4 === 0 && this.month === 2) {
-      return 29;
-    }
-    return DAYS_OF_MONTH[month];
+    return this.year % 4 === 0 && this.month === 2 ? 29 : DAYS_OF_MONTH[month];
   }
   prevMonth(): { year: number; month: number } {
-    if (this.month === 1) {
-      return { year: this.year - 1, month: 12 };
-    }
-    return { year: this.year, month: this.month - 1 };
+    return this.month === 1
+      ? { year: this.year - 1, month: 12 }
+      : { year: this.year, month: this.month - 1 };
   }
   nextMonth(): { year: number; month: number } {
-    if (this.month === 12) {
-      return { year: this.year + 1, month: 1 };
-    }
-    return { year: this.year, month: this.month + 1 };
+    return this.month === 12
+      ? { year: this.year + 1, month: 1 }
+      : { year: this.year, month: this.month + 1 };
   }
   createCalenderElements(
     days: number,

--- a/src/lib/calender.ts
+++ b/src/lib/calender.ts
@@ -25,6 +25,11 @@ interface Calenderable {
 class CalenderElement implements CalenderElementable {
   private _events: string[] = [];
   constructor(readonly date: number, readonly isInCurrentMonth: boolean) {}
+  filterEvents(innerEvents: Array<InnerEvent>): void {
+    this.events = innerEvents
+      .filter(n => n.date === this.date)
+      .map(m => m.value);
+  }
   get events(): string[] {
     return this._events;
   }
@@ -52,7 +57,7 @@ export class Calender implements Calenderable {
   filterEvents(events: Array<Event>): void {
     this.innerEvents = events
       .filter(n => n.date[0] === this.year && n.date[1] === this.month)
-      .map(n => new InnerEvent(n.date[2], n.value));
+      .map(m => new InnerEvent(m.date[2], m.value));
   }
   firstDay(): string {
     return String(this.month) + ' 1, ' + String(this.year);
@@ -80,9 +85,11 @@ export class Calender implements Calenderable {
     isIn: boolean,
     gap = 1
   ): Array<CalenderElement> {
-    return new Array(days)
-      .fill(0)
-      .map((_, i) => new CalenderElement(i + gap, isIn));
+    return new Array(days).fill(0).map((_, i) => {
+      const calenderElement = new CalenderElement(i + gap, isIn);
+      calenderElement.filterEvents(this.innerEvents);
+      return calenderElement;
+    });
   }
   get calenderElements(): Array<CalenderElement> {
     const currentDays = this.daysOfMonthOfYear();

--- a/src/lib/calenderElement.ts
+++ b/src/lib/calenderElement.ts
@@ -1,0 +1,24 @@
+import { InnerEvent } from './event';
+import { omitt } from './common';
+
+interface CalenderElementable {
+  readonly date: number;
+  readonly isInCurrentMonth: boolean;
+  readonly events: string[];
+}
+
+export class CalenderElement implements CalenderElementable {
+  private _events: string[] = [];
+  constructor(readonly date: number, readonly isInCurrentMonth: boolean) {}
+  filterEvents(innerEvents: Array<InnerEvent>): void {
+    this.events = innerEvents
+      .filter(n => n.date === this.date)
+      .map(m => omitt(m.value));
+  }
+  get events(): string[] {
+    return this._events;
+  }
+  set events(newEvents: string[]) {
+    this._events = newEvents;
+  }
+}

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -1,0 +1,19 @@
+export const DAYS_OF_MONTH = [
+  31,
+  31,
+  28,
+  31,
+  30,
+  31,
+  30,
+  31,
+  31,
+  30,
+  31,
+  30,
+  31,
+];
+export const DAYS_OF_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+export function omitt(value: string, limit = 7): string {
+  return value.length > limit ? value.slice(0, limit) + '...' : value;
+}

--- a/src/lib/event.ts
+++ b/src/lib/event.ts
@@ -1,0 +1,20 @@
+interface Eventable {
+  readonly date: [number, number, number];
+  readonly value: string;
+}
+
+export interface InnerEventable {
+  readonly date: number;
+  readonly value: string;
+}
+
+export class Event implements Eventable {
+  constructor(
+    readonly date: [number, number, number],
+    readonly value: string
+  ) {}
+}
+
+export class InnerEvent implements InnerEventable {
+  constructor(readonly date: number, readonly value: string) {}
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -97,7 +97,7 @@ theme.typography = {
     fontFamily: 'Koruri, Arial',
     whiteSpace: 'pre-line',
     fontSize: 16,
-    lineHeight: '32px',
+    marginBottom: 2,
     color: '#030303',
     [theme.breakpoints.down('xs')]: {
       fontSize: 14,
@@ -106,10 +106,10 @@ theme.typography = {
   },
   body2: {
     fontFamily: 'Koruri, Arial',
-    fontSize: 16,
+    fontSize: 12,
     color: '#030303',
     [theme.breakpoints.down('xs')]: {
-      fontSize: 14,
+      fontSize: 10,
     },
   },
   button: {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -24,6 +24,7 @@ theme.typography = {
   h1: {
     fontFamily: 'Audiowide',
     fontSize: 80,
+    marginTop: -12,
     whiteSpace: 'pre-line',
     color: palette.primary.main,
     [theme.breakpoints.down('xs')]: {
@@ -97,8 +98,6 @@ theme.typography = {
     fontFamily: 'Koruri, Arial',
     whiteSpace: 'pre-line',
     fontSize: 16,
-    marginBottom: 2,
-    color: '#030303',
     [theme.breakpoints.down('xs')]: {
       fontSize: 14,
       lineHeight: '28px',

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -1,5 +1,6 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 import { InputActions, CalenderActions } from 'redux/actions';
+import { Event } from 'lib/event';
 
 export interface State {
   inputValue: string;
@@ -7,6 +8,7 @@ export interface State {
   clickCount: number;
   year: number;
   month: number;
+  events: Array<Event>;
 }
 
 export const initialState: State = {
@@ -15,6 +17,10 @@ export const initialState: State = {
   clickCount: 0,
   year: 2020,
   month: 3,
+  events: [
+    { date: [2020, 3, 6], value: 'マッドマックス' },
+    { date: [2020, 4, 3], value: '入社式' },
+  ],
 };
 
 export const Reducer = reducerWithInitialState(initialState)

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -21,7 +21,7 @@ export const initialState: State = {
     { date: [2020, 3, 6], value: 'マッドマックス' },
     { date: [2020, 3, 6], value: '健康診断' },
     { date: [2020, 3, 15], value: '兄の誕生日' },
-    { date: [2020, 3, 25], value: '学位授与の日' },
+    { date: [2020, 3, 25], value: '学位授与の日だったけどなくなった' },
     { date: [2020, 4, 3], value: '入社式' },
   ],
 };

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -20,6 +20,8 @@ export const initialState: State = {
   events: [
     { date: [2020, 3, 6], value: 'マッドマックス' },
     { date: [2020, 3, 6], value: '健康診断' },
+    { date: [2020, 3, 15], value: '兄の誕生日' },
+    { date: [2020, 3, 25], value: '学位授与の日' },
     { date: [2020, 4, 3], value: '入社式' },
   ],
 };

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -19,6 +19,7 @@ export const initialState: State = {
   month: 3,
   events: [
     { date: [2020, 3, 6], value: 'マッドマックス' },
+    { date: [2020, 3, 6], value: '健康診断' },
     { date: [2020, 4, 3], value: '入社式' },
   ],
 };


### PR DESCRIPTION
## 🍔 やったこと
### view
- ユーザーが追加したイベントを表示する`Events`及びイベント数のみを表示する
`EventCounter`を実装.
- 色の使い方を見直してシンプルにした.
### logic
- ユーザーが追加するイベントを表す`State`として`events`を定義.
- 表示するカレンダー作成時に`State.events`を受け取り, カレンダーに反映させるロジックを`lib/calender`に追加, 及び`lib/event`を作成.
- 全体的なリファクタリングも合わせて行った.
<br />

## 🍣 できるようになったこと
- カレンダー上に追加されたイベントが確認できる.
  - PC

![image](https://user-images.githubusercontent.com/39250854/76001273-31711500-5f48-11ea-949c-5e5d60e0bde0.png)

  - モバイル

![image](https://user-images.githubusercontent.com/39250854/76001598-ae03f380-5f48-11ea-9f1c-5c87880543a1.png)

<br />

## 🍕 やってないこと
### view
- イベント追加時のダイアログの表示.
### logic
- イベント追加用のアクション及びディスパッチャの定義.
- 1日毎のイベント追加可能数 or 表示するイベント数の制限.
<br />