### PR TITLE
イベントの削除機能の実装 (リバート後の修正を反映)

### DIFF
--- a/src/components/EventDialog.tsx
+++ b/src/components/EventDialog.tsx
@@ -54,6 +54,7 @@ export const EventDialog: React.FC<Props> = props => {
     handleClearCurrentElement,
     handleUpdateInputEventValue,
     handleAddEvent,
+    handleReomveEvent,
   } = props;
   const dayOfWeek =
     DAYS_OF_WEEK[
@@ -72,6 +73,10 @@ export const EventDialog: React.FC<Props> = props => {
       handleCloseThis();
     }
   };
+  const handleRemoveEventAndClose: (eventId: number) => void = eventId => {
+    handleReomveEvent(eventId);
+    handleCloseThis();
+  };
 
   if (!currentElement) {
     return <div />;
@@ -88,7 +93,12 @@ export const EventDialog: React.FC<Props> = props => {
         <span className={classes.dayOfWeek}>{dayOfWeek}</span>
       </DialogTitle>
       <DialogContent className={classes.content}>
-        <Events events={currentElement.events} large />
+        <Events
+          events={currentElement.events}
+          eventIds={currentElement.eventIds}
+          handleRemove={handleRemoveEventAndClose}
+          large
+        />
         <TextField
           autoFocus
           id="new-event"

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -15,9 +15,6 @@ const useStyles = makeStyles(theme => ({
   removeButton: {
     padding: 2,
     color: '#fafafa',
-    [theme.breakpoints.down('xs')]: {
-      marginLeft: -16,
-    },
   },
   counterWrapper: {
     display: 'flex',

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -15,6 +15,9 @@ const useStyles = makeStyles(theme => ({
   removeButton: {
     padding: 2,
     color: '#fafafa',
+    [theme.breakpoints.down('xs')]: {
+      marginLeft: -16,
+    },
   },
   counterWrapper: {
     display: 'flex',

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -1,13 +1,20 @@
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, IconButton, Grid } from '@material-ui/core';
 import { Typography } from '@material-ui/core';
+import { Cancel } from '@material-ui/icons';
 
 const useStyles = makeStyles(theme => ({
-  event: {
+  eventWrapper: {
+    backgroundColor: theme.palette.secondary.light,
     marginTop: 2,
+  },
+  event: {
     padding: '0 2px',
     color: '#030303',
-    backgroundColor: theme.palette.secondary.light,
+  },
+  removeButton: {
+    padding: 2,
+    color: '#fafafa',
   },
   counterWrapper: {
     display: 'flex',
@@ -19,23 +26,57 @@ const useStyles = makeStyles(theme => ({
 
 type Props = {
   events: string[];
+  eventIds?: number[];
   large?: boolean;
+  handleRemove?(eventId: number): void;
+};
+
+type SubProps = {
+  event: string;
+  i: number;
 };
 
 export const Events: React.FC<Props> = props => {
   const classes = useStyles();
-  const { events, large = false } = props;
+  const { events, eventIds = [], large = false, handleRemove } = props;
+  const handleRemoveSafety: (eventId: number) => void = (eventId: number) => {
+    if (handleRemove) {
+      handleRemove(eventId);
+    }
+  };
+
+  const Event: React.FC<SubProps> = props => (
+    <Grid
+      container
+      className={classes.eventWrapper}
+      justify="flex-end"
+      alignItems="center"
+    >
+      <Grid item xs={large ? 11 : 12}>
+        <Typography
+          variant={large ? 'body1' : 'body2'}
+          className={classes.event}
+        >
+          {props.event}
+        </Typography>
+      </Grid>
+      {large && (
+        <Grid item xs={1}>
+          <IconButton
+            onClick={() => handleRemoveSafety(eventIds[props.i])}
+            className={classes.removeButton}
+          >
+            <Cancel fontSize="small" />
+          </IconButton>
+        </Grid>
+      )}
+    </Grid>
+  );
 
   return (
     <div>
       {events.map((event, i) => (
-        <Typography
-          key={i}
-          variant={large ? 'body1' : 'body2'}
-          className={classes.event}
-        >
-          {event}
-        </Typography>
+        <Event key={i} {...{ event, i }} />
       ))}
     </div>
   );

--- a/src/containers/CalenderBoardContainer.ts
+++ b/src/containers/CalenderBoardContainer.ts
@@ -5,6 +5,7 @@ import { CalenderBoard } from 'components/CalenderBoard';
 import { Dispatch } from 'react';
 import { Event } from 'lib/event';
 import { CalenderElement } from 'lib/calenderElement';
+import { Action } from 'redux';
 
 interface StateAtProps {
   year: number;
@@ -28,7 +29,9 @@ const mapStateToProps = (appState: Appstate): StateAtProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch<any>): CalenderBoardHandler => {
+const mapDispatchToProps = (
+  dispatch: Dispatch<Action>
+): CalenderBoardHandler => {
   return {
     handleChangeMonth: ({ year, month }) => {
       dispatch(CalenderActions.updateCurrentMonth({ year, month }));

--- a/src/containers/EventDialogContainer.ts
+++ b/src/containers/EventDialogContainer.ts
@@ -5,6 +5,7 @@ import { Dispatch } from 'react';
 import { EventDialog } from 'components/EventDialog';
 import { CalenderElement } from 'lib/calenderElement';
 import { Event } from 'lib/event';
+import { Action } from 'redux';
 
 interface StateAtProps {
   year: number;
@@ -19,6 +20,7 @@ export interface EventDialogHandler {
   handleToggleDialog(): void;
   handleUpdateInputEventValue(inputEventValue: string): void;
   handleAddEvent(newEvent: Event): void;
+  handleReomveEvent(eventId: number): void;
 }
 
 const mapStateToProps = (appState: Appstate): StateAtProps => {
@@ -31,7 +33,7 @@ const mapStateToProps = (appState: Appstate): StateAtProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch<any>): EventDialogHandler => {
+const mapDispatchToProps = (dispatch: Dispatch<Action>): EventDialogHandler => {
   return {
     handleClearCurrentElement: () => {
       dispatch(CalenderActions.clearCurrentElement());
@@ -44,6 +46,9 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): EventDialogHandler => {
     },
     handleAddEvent: newEvent => {
       dispatch(EventActions.addEvent(newEvent));
+    },
+    handleReomveEvent: eventId => {
+      dispatch(EventActions.removeEvent(eventId));
     },
   };
 };

--- a/src/lib/calender.ts
+++ b/src/lib/calender.ts
@@ -28,7 +28,7 @@ export class Calender implements Calenderable {
   filterEvents(events: Array<Event>): void {
     this.innerEvents = events
       .filter(n => n.date[0] === this.year && n.date[1] === this.month)
-      .map(m => new InnerEvent(m.date[2], m.value));
+      .map(m => new InnerEvent(m.date[2], m.value, events.indexOf(m)));
   }
   firstDay(): string {
     return String(this.month) + ' 1, ' + String(this.year);

--- a/src/lib/calenderElement.ts
+++ b/src/lib/calenderElement.ts
@@ -6,17 +6,24 @@ interface CalenderElementable {
   readonly isInCurrentMonth: boolean;
   readonly events: string[];
   readonly omittedEvents: string[];
+  readonly eventIds: number[];
 }
 
 export class CalenderElement implements CalenderElementable {
   private _events: string[] = [];
   private _omittedEvents: string[] = [];
+  private _eventIds: number[] = [];
   constructor(readonly date: number, readonly isInCurrentMonth: boolean) {}
   filterEvents(innerEvents: Array<InnerEvent>): void {
-    this.events = innerEvents
+    const tmpEvents: [string, number][] = innerEvents
       .filter(n => n.date === this.date)
-      .map(m => m.value);
-    this.omittedEvents = this.events.map(n => omitt(n));
+      .map(m => [m.value, m.baseId]);
+    for (let index = 0; index < tmpEvents.length; index++) {
+      const element = tmpEvents[index];
+      this.events.push(element[0]);
+      this.eventIds.push(element[1]);
+      this.omittedEvents.push(omitt(element[0]));
+    }
   }
   get events(): string[] {
     return this._events;
@@ -29,5 +36,11 @@ export class CalenderElement implements CalenderElementable {
   }
   set omittedEvents(newEvents: string[]) {
     this._omittedEvents = newEvents;
+  }
+  get eventIds(): number[] {
+    return this._eventIds;
+  }
+  set eventIds(newIds: number[]) {
+    this._eventIds = newIds;
   }
 }

--- a/src/lib/event.ts
+++ b/src/lib/event.ts
@@ -6,6 +6,7 @@ interface Eventable {
 export interface InnerEventable {
   readonly date: number;
   readonly value: string;
+  readonly baseId: number;
 }
 
 export class Event implements Eventable {
@@ -16,5 +17,9 @@ export class Event implements Eventable {
 }
 
 export class InnerEvent implements InnerEventable {
-  constructor(readonly date: number, readonly value: string) {}
+  constructor(
+    readonly date: number,
+    readonly value: string,
+    readonly baseId: number
+  ) {}
 }

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -15,6 +15,7 @@ export const CalenderActions = {
 };
 export const EventActions = {
   addEvent: actionCreater<Event>('ADD_EVENT'),
+  removeEvent: actionCreater<number>('REMOVE_EVENT'),
   toggleDialog: actionCreater('TOGGLE_DIALOG'),
   updateInputEventValue: actionCreater<string>('UPDATE_INPUT_EVENT_VALUE'),
 };

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -40,6 +40,10 @@ export const Reducer = reducerWithInitialState(initialState)
   .case(EventActions.addEvent, (state, newEvent) => {
     return { ...state, events: [...state.events, newEvent] };
   })
+  .case(EventActions.removeEvent, (state, eventId) => {
+    state.events.splice(eventId, 1);
+    return { ...state, events: state.events };
+  })
   .case(EventActions.toggleDialog, state => {
     return { ...state, dialogIsOpen: !state.dialogIsOpen };
   })


### PR DESCRIPTION
## 🍔 やったこと
### view
- `EventDialog`上の`Events`に削除ボタンを設置.
### logic
- イベント削除用の`action`及び`dispatcher`の定義.
- `State.events`の(絶対的)インデックスをロジック側に渡せるようにした.
  - `CalenderElement`毎に`State.events`を振り分けるので, 
ロジッククラス内の(相対的)インデックスを使って削除はできない.
<br />

## 🍣 できるようになったこと
- イベントの削除.

![200307-removeevent](https://user-images.githubusercontent.com/39250854/76137387-cd516c80-607f-11ea-8f5b-3066ef114079.gif)

<br />

## 🍕 やってないこと
### view
- **閉じるボタンのレイアウトのモバイル画面の対応. => リバートして実装済み.**
<br />